### PR TITLE
Make the class public and add a parameterless constructor

### DIFF
--- a/AccidentalFish.AspNet.Identity.Azure/TableUserLoginProviderKeyIndex.cs
+++ b/AccidentalFish.AspNet.Identity.Azure/TableUserLoginProviderKeyIndex.cs
@@ -4,7 +4,7 @@ using Microsoft.WindowsAzure.Storage.Table;
 
 namespace AccidentalFish.AspNet.Identity.Azure
 {
-    class TableUserLoginProviderKeyIndex : TableEntity
+    public class TableUserLoginProviderKeyIndex : TableEntity
     {
         public TableUserLoginProviderKeyIndex(string userId, string loginProviderKey, string loginProvider)
         {
@@ -12,6 +12,9 @@ namespace AccidentalFish.AspNet.Identity.Azure
             RowKey = "";
             UserId = userId;
         }
+        
+        // Add a parameterless constructor to resolve issue in TableUserStore.cs FindAsync
+        public TableUserLoginProviderKeyIndex() { }
 
         public string GetLoginProvider()
         {


### PR DESCRIPTION
Hi James - great work on this project really like what you are doing: hope this helps;

Adding a parameterless constructor resolve issue in TableUserStore.cs FindAsync which previously resulted in the following error:

<ExceptionMessage>
TableQuery Generic Type must provide a default parameterless constructor.
</ExceptionMessage>

Regards,

James.
