### PR TITLE
Fixed cast issue in FindByEmailAsync()

### DIFF
--- a/AccidentalFish.AspNet.Identity.Azure/TableUserStore.cs
+++ b/AccidentalFish.AspNet.Identity.Azure/TableUserStore.cs
@@ -455,14 +455,11 @@ namespace AccidentalFish.AspNet.Identity.Azure
         {
             if (String.IsNullOrWhiteSpace(email)) return null;
 
-            TableOperation retrieveIndexOp = TableOperation.Retrieve<TableUserEmailIndex>(email.Base64Encode(), "");
-            TableResult indexResult = await _userEmailIndexTable.ExecuteAsync(retrieveIndexOp);
-            if (indexResult.Result != null)
-            {
-                T user = (T) indexResult.Result;
-                return await FindByIdAsync(user.Id);
-            }
-            return null;
+            var retrieveIndexOp = TableOperation.Retrieve<TableUserEmailIndex>(email.Base64Encode(), "");
+            var indexResult = await _userEmailIndexTable.ExecuteAsync(retrieveIndexOp);
+            if (indexResult.Result == null) return null;
+            var user = (TableUserEmailIndex)indexResult.Result;
+            return await FindByIdAsync(user.UserId);
         }
 
         public Task SetPhoneNumberAsync(T user, string phoneNumber)


### PR DESCRIPTION
FindByEmailAsync() was throwing an invalid cast exception when there
were users in the store. The return type of indexResult.Result is
TableUserEmailIndex instead of the expected ApplicationUser. I've
changed the cast and usage, which now works.
