### PR TITLE
Fixed several things

### DIFF
--- a/AccidentalFish.AspNet.Identity.Azure/Extensions/StringExtensions.cs
+++ b/AccidentalFish.AspNet.Identity.Azure/Extensions/StringExtensions.cs
@@ -8,12 +8,12 @@ namespace AccidentalFish.AspNet.Identity.Azure.Extensions
         public static string Base64Encode(this string plainText)
         {
             var plainTextBytes = Encoding.UTF8.GetBytes(plainText);
-            return Convert.ToBase64String(plainTextBytes);
+            return Convert.ToBase64String(plainTextBytes).Replace("/","-");
         }
 
         public static string Base64Decode(this string base64EncodedData)
         {
-            var base64EncodedBytes = Convert.FromBase64String(base64EncodedData);
+            var base64EncodedBytes = Convert.FromBase64String(base64EncodedData.Replace("-","/"));
             return Encoding.UTF8.GetString(base64EncodedBytes);
         }
     }

--- a/AccidentalFish.AspNet.Identity.Azure/TableUserClaim.cs
+++ b/AccidentalFish.AspNet.Identity.Azure/TableUserClaim.cs
@@ -22,7 +22,7 @@ namespace AccidentalFish.AspNet.Identity.Azure
         public void SetPartitionAndRowKey()
         {
             PartitionKey = UserId;
-            RowKey = ClaimType.Base64Encode().Replace("/","-");
+            RowKey = ClaimType.Base64Encode();
         }
 
         public string UserId { get; set; }

--- a/AccidentalFish.AspNet.Identity.Azure/TableUserIndexBuilder.cs
+++ b/AccidentalFish.AspNet.Identity.Azure/TableUserIndexBuilder.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
+using AccidentalFish.AspNet.Identity.Azure.Extensions;
 
 namespace AccidentalFish.AspNet.Identity.Azure
 {
@@ -41,7 +42,7 @@ namespace AccidentalFish.AspNet.Identity.Azure
                 querySegment = await _userTable.ExecuteQuerySegmentedAsync(query, querySegment != null ? querySegment.ContinuationToken : null);
                 foreach (TableUser tableUser in querySegment.Results)
                 {
-                    TableUserIdIndex indexItem = new TableUserIdIndex(tableUser.UserName, tableUser.Id);
+                    TableUserIdIndex indexItem = new TableUserIdIndex(tableUser.UserName.Base64Encode(), tableUser.Id);
                     insertOperation.Add(_userIndexTable.ExecuteAsync(TableOperation.InsertOrReplace(indexItem)));
                     if (insertOperation.Count > 100)
                     {

--- a/AccidentalFish.AspNet.Identity.Azure/TableUserLoginIdIndex.cs
+++ b/AccidentalFish.AspNet.Identity.Azure/TableUserLoginIdIndex.cs
@@ -9,10 +9,10 @@ namespace AccidentalFish.AspNet.Identity.Azure
             
         }
 
-        public TableUserIdIndex(string userName, string userId)
+        public TableUserIdIndex(string base64UserName, string userId)
         {
-            PartitionKey = userName;
-            RowKey = userName;
+            PartitionKey = base64UserName;
+            RowKey = base64UserName;
             UserId = userId;
         }
 

--- a/AccidentalFish.AspNet.Identity.Azure/TableUserLoginProviderKeyIndex.cs
+++ b/AccidentalFish.AspNet.Identity.Azure/TableUserLoginProviderKeyIndex.cs
@@ -8,7 +8,7 @@ namespace AccidentalFish.AspNet.Identity.Azure
     {
         public TableUserLoginProviderKeyIndex(string userId, string loginProviderKey, string loginProvider)
         {
-            PartitionKey = String.Format("{0}_{1}", loginProvider, loginProviderKey.Base64Encode());
+            PartitionKey = String.Format("{0}_{1}", loginProvider.Base64Encode(), loginProviderKey.Base64Encode());
             RowKey = "";
             UserId = userId;
         }
@@ -18,7 +18,7 @@ namespace AccidentalFish.AspNet.Identity.Azure
 
         public string GetLoginProvider()
         {
-            return PartitionKey.Substring(0, PartitionKey.IndexOf('_')-1);
+            return PartitionKey.Substring(0, PartitionKey.IndexOf('_')-1).Base64Decode();
         }
 
         public string GetLoginProviderKey()

--- a/AccidentalFish.AspNet.Identity.Azure/TableUserRole.cs
+++ b/AccidentalFish.AspNet.Identity.Azure/TableUserRole.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.AspNet.Identity;
 using Microsoft.WindowsAzure.Storage.Table;
+using AccidentalFish.AspNet.Identity.Azure.Extensions;
 
 namespace AccidentalFish.AspNet.Identity.Azure
 {
@@ -22,7 +23,7 @@ namespace AccidentalFish.AspNet.Identity.Azure
         public void SetPartitionAndRowKey()
         {
             PartitionKey = UserId;
-            RowKey = Name;
+            RowKey = Name.Base64Encode();
         }
 
         public string UserId { get; set; }


### PR DESCRIPTION
I noticed that I couldn't use claims with a claim type of ClaimTypes.Role because it evaluates to "http://schemas.microsoft.com/ws/2008/06/identity/claims/role". The '/' character is not allowed in the keys and the claim type was being used as a key. I changed that key to use the base64 encoded value of the claim type instead. Unfortunately, the '/' character happens to be one of the two non alphanumeric characters that base64 encoding uses, so I also had to change the encoding extension to use '-' instead of '/'.

There were several other values that were being used as keys that could potentially contain illegal characters, so I applied the base64 encoding to those keys as well.

Another thing that I noticed was that when a user is deleted, all of the indices, claims, roles, and logins for the user are not deleted. I added some code to clean all of that up when a user is deleted.

The last thing is that when doing a replace, merge, or delete operation on a table, a valid ETag is required. The ETag will already be set if you get the object from a retrieve or query operation but if you try to create a new object, set it's keys, and then delete it, it wont work because the ETag isn't set. I added lines to set the ETag to a wildcard character before attempting to delete anything created this way.

I also integrated Amethi's fix for login indices.
